### PR TITLE
add required `designated_model` metadata field

### DIFF
--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -69,6 +69,10 @@
                 "OGL-3.0"
             ]
         },
+        "designated_model": {
+            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization. A team may designate up to two models.",
+            "type": "boolean"
+        },
         "citation": {
             "description": "One or more citations for this model",
             "type": "string",
@@ -110,6 +114,7 @@
         "model_abbr",
         "model_contributors",
         "license",
+        "designated_model",
         "methods",
         "data_sources"
     ]

--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -70,7 +70,7 @@
             ]
         },
         "designated_model": {
-            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization. A team may designate up to two models.",
+            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization.",
             "type": "boolean"
         },
         "citation": {

--- a/model-metadata/epiENGAGE-Copycat.yml
+++ b/model-metadata/epiENGAGE-Copycat.yml
@@ -12,6 +12,7 @@ model_contributors: [
   }
 ]
 license: "CC-BY-4.0"
+designated_model: false
 team_funding: "CSTE/CDC award NU38OT000297"
 methods: "A pattern matching model that matches growth rate trends to historic growth rate curves."
 methods_url: "https://thefoxlab.wordpress.com/"

--- a/model-metadata/epiENGAGE-Copycat.yml
+++ b/model-metadata/epiENGAGE-Copycat.yml
@@ -12,7 +12,7 @@ model_contributors: [
   }
 ]
 license: "CC-BY-4.0"
-designated_model: false
+designated_model: true
 team_funding: "CSTE/CDC award NU38OT000297"
 methods: "A pattern matching model that matches growth rate trends to historic growth rate curves."
 methods_url: "https://thefoxlab.wordpress.com/"

--- a/model-metadata/epiENGAGE-GBQR.yml
+++ b/model-metadata/epiENGAGE-GBQR.yml
@@ -31,7 +31,7 @@ model_contributors: [
   },
 ]
 license: "CC-BY-4.0"
-designated_model: false
+designated_model: true
 team_funding: ""
 methods: "A Gradient Boosting of Quantile Regression (GBQR) model for city level flu forecasts. A machine learning method that combines gradient boosting and quantile regression to predict conditional quantiles, providing insights into uncertainty and variability in predictions."
 methods_url: "https://github.com/donga0223/City-Level-Forecasting/tree/main/GBQR"

--- a/model-metadata/epiENGAGE-GBQR.yml
+++ b/model-metadata/epiENGAGE-GBQR.yml
@@ -31,6 +31,7 @@ model_contributors: [
   },
 ]
 license: "CC-BY-4.0"
+designated_model: false
 team_funding: ""
 methods: "A Gradient Boosting of Quantile Regression (GBQR) model for city level flu forecasts. A machine learning method that combines gradient boosting and quantile regression to predict conditional quantiles, providing insights into uncertainty and variability in predictions."
 methods_url: "https://github.com/donga0223/City-Level-Forecasting/tree/main/GBQR"

--- a/model-metadata/epiENGAGE-INFLAenza.yml
+++ b/model-metadata/epiENGAGE-INFLAenza.yml
@@ -29,7 +29,7 @@ model_contributors: [
   }
 ]
 license: "CC-BY-4.0"
-designated_model: false
+designated_model: true
 team_funding: ""
 methods: "A spatial time-series model that uses the R-INLA package for estimating forecast posterior distributions."
 methods_url: "https://github.com/donga0223/City-Level-Forecasting/tree/main/INLA"

--- a/model-metadata/epiENGAGE-INFLAenza.yml
+++ b/model-metadata/epiENGAGE-INFLAenza.yml
@@ -29,6 +29,7 @@ model_contributors: [
   }
 ]
 license: "CC-BY-4.0"
+designated_model: false
 team_funding: ""
 methods: "A spatial time-series model that uses the R-INLA package for estimating forecast posterior distributions."
 methods_url: "https://github.com/donga0223/City-Level-Forecasting/tree/main/INLA"

--- a/model-metadata/epiforecasts-dyngam.yml
+++ b/model-metadata/epiforecasts-dyngam.yml
@@ -12,7 +12,7 @@ model_contributors: [
   }
 ]
 license: "CC-BY-4.0"
-designated_model: false
+designated_model: true
 team_funding: ""
 methods: "A Bayesian hierarchical GAM with a univariate AR(1) process"
 methods_url: "https://github.com/epiforecasts/cityforecasts/blob/main/README.md"

--- a/model-metadata/epiforecasts-dyngam.yml
+++ b/model-metadata/epiforecasts-dyngam.yml
@@ -12,6 +12,7 @@ model_contributors: [
   }
 ]
 license: "CC-BY-4.0"
+designated_model: false
 team_funding: ""
 methods: "A Bayesian hierarchical GAM with a univariate AR(1) process"
 methods_url: "https://github.com/epiforecasts/cityforecasts/blob/main/README.md"


### PR DESCRIPTION
This change enables using the repo with https://github.com/hubverse-org/hub-dashboard-predtimechart , which currently requires the `designated_model` metadata field.