### PR TITLE
fix validate-submission.yaml

### DIFF
--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-	  pak-version: "devel"
+          pak-version: "devel"
           packages: |
             any::hubValidations
             any::sessioninfo


### PR DESCRIPTION
The previous change used tabs instead of spaces.